### PR TITLE
Check calling contract

### DIFF
--- a/LUW.py
+++ b/LUW.py
@@ -39,7 +39,7 @@ class LUW(sp.Contract):
         sp.set_type(provider_id, sp.TString)
         sp.set_type(luw_service_endpoint, sp.TAddress)
 
-        # Verifying whether the caller address is the logic contract
+        # Verifying whether the calling contract address is the logic contract
         sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender,
                   message="Incorrect caller")
 
@@ -59,7 +59,7 @@ class LUW(sp.Contract):
         sp.set_type(luw_id, sp.TNat)
         sp.set_type(state_id, sp.TNat)
 
-        # Verifying whether the caller address is the logic contract
+        # Verifying whether the calling contract address is the logic contract
         sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender,
                   message="Incorrect caller")
 
@@ -88,7 +88,7 @@ class LUW(sp.Contract):
         sp.set_type(repository_id, sp.TString)
         sp.set_type(state_id, sp.TNat)
 
-        # Verifying whether the caller address is the logic contract
+        # Verifying whether the calling contract address is the logic contract
         sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender,
                   message="Incorrect caller")
 
@@ -118,7 +118,7 @@ class LUW(sp.Contract):
         sp.set_type(repository_id, sp.TString)
         sp.set_type(state_id, sp.TNat)
 
-        # Verifying whether the caller address is the logic contract
+        # Verifying whether the calling contract address is the logic contract
         sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender,
                   message="Incorrect caller")
 

--- a/LUW.py
+++ b/LUW.py
@@ -3,7 +3,7 @@
 import smartpy as sp
 
 class LUW(sp.Contract):
-    def __init__(self):
+    def __init__(self, certifier):
         self.init_type(
             sp.TRecord(
                 luw_map = sp.TBigMap(
@@ -23,17 +23,25 @@ class LUW(sp.Contract):
                     )
                 ),
                 luw_last_id = sp.TNat,
+                logic_contract_address = sp.TOption(sp.TAddress),
+                certifier = sp.TAddress
             )
         )
         self.init(
             luw_map = sp.big_map(),
             luw_last_id = 0,
+            logic_contract_address = sp.none,
+            certifier = certifier
         )
 
     @sp.entry_point
     def add(self, provider_id, luw_service_endpoint):
         sp.set_type(provider_id, sp.TString)
         sp.set_type(luw_service_endpoint, sp.TAddress)
+
+        # Verifying whether the caller address is the logic contract
+        sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender,
+                  message="Incorrect caller")
 
         new_luw_record = sp.record(
             creator_wallet_address = sp.source,
@@ -50,6 +58,10 @@ class LUW(sp.Contract):
     def add_state(self, luw_id, state_id):
         sp.set_type(luw_id, sp.TNat)
         sp.set_type(state_id, sp.TNat)
+
+        # Verifying whether the caller address is the logic contract
+        sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender,
+                  message="Incorrect caller")
 
         sp.verify(self.data.luw_map.contains(luw_id), message = "LUW ID does not exist")
 
@@ -75,6 +87,10 @@ class LUW(sp.Contract):
         sp.set_type(luw_id, sp.TNat)
         sp.set_type(repository_id, sp.TString)
         sp.set_type(state_id, sp.TNat)
+
+        # Verifying whether the caller address is the logic contract
+        sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender,
+                  message="Incorrect caller")
 
         sp.verify(self.data.luw_map.contains(luw_id), message = "LUW ID does not exist")
 
@@ -102,6 +118,10 @@ class LUW(sp.Contract):
         sp.set_type(repository_id, sp.TString)
         sp.set_type(state_id, sp.TNat)
 
+        # Verifying whether the caller address is the logic contract
+        sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender,
+                  message="Incorrect caller")
+
         sp.verify(self.data.luw_map.contains(luw_id), message = "LUW ID does not exist")
 
         luw = self.data.luw_map[luw_id]
@@ -119,6 +139,16 @@ class LUW(sp.Contract):
         )
 
         self.data.luw_map[luw_id] = new_luw_record
+
+
+    @sp.entry_point
+    def change_logic_contract_address(self, new_logic_contract_address):
+        with sp.if_(self.data.certifier != sp.source):
+            sp.failwith("Incorrect certifier")
+
+        # Update logic contract address
+        self.data.logic_contract_address = sp.some(new_logic_contract_address)
+
 
     @sp.onchain_view()
     def fetch(self, luw_id):
@@ -147,5 +177,5 @@ class LUW(sp.Contract):
 @sp.add_test(name = "LUW")
 def test():
     sp.add_compilation_target("luw",
-        LUW()
+        LUW(sp.address('tz1_certifier_address'))
     )

--- a/LUWRepository.py
+++ b/LUWRepository.py
@@ -104,6 +104,10 @@ class LUWRepository(sp.Contract):
         sp.set_type(provider_id, sp.TString)
         sp.set_type(luw_service_endpoint, sp.TAddress)
 
+        # Verifying whether the calling contract address is the logic contract
+        sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender,
+                  message="Incorrect caller")
+
         # Defining the data that we expect as a return from the Logic contract
         data_schema = sp.TRecord(provider_id = sp.TString, luw_service_endpoint = sp.TAddress)
 
@@ -123,6 +127,10 @@ class LUWRepository(sp.Contract):
     def change_luw_state(self, luw_id, state_id):
         sp.set_type(luw_id, sp.TNat)
         sp.set_type(state_id, sp.TNat)
+
+        # Verifying whether the calling contract address is the logic contract
+        sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender,
+                  message="Incorrect caller")
 
         sp.verify(self.data.states.contains(state_id), message = "Incorrect state ID")
 
@@ -152,6 +160,10 @@ class LUWRepository(sp.Contract):
     def add_repository(self, luw_id, repository_id):
         sp.set_type(luw_id, sp.TNat)
         sp.set_type(repository_id, sp.TString)
+
+        # Verifying whether the calling contract address is the logic contract
+        sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender,
+                  message="Incorrect caller")
 
         owner_address = self.get_luw_owner_address(luw_id)
         sp.verify(self.verify_owner_source_address(
@@ -188,6 +200,10 @@ class LUWRepository(sp.Contract):
         sp.set_type(luw_id, sp.TNat)
         sp.set_type(repository_id, sp.TString)
         sp.set_type(state_id, sp.TNat)
+
+        # Verifying whether the calling contract address is the logic contract
+        sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender,
+                  message="Incorrect caller")
 
         owner_address = self.get_luw_owner_address(luw_id)
         sp.verify(self.verify_owner_source_address(

--- a/LUWRepository.py
+++ b/LUWRepository.py
@@ -104,10 +104,6 @@ class LUWRepository(sp.Contract):
         sp.set_type(provider_id, sp.TString)
         sp.set_type(luw_service_endpoint, sp.TAddress)
 
-        # Verifying whether the calling contract address is the logic contract
-        sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender,
-                  message="Incorrect caller")
-
         # Defining the data that we expect as a return from the Logic contract
         data_schema = sp.TRecord(provider_id = sp.TString, luw_service_endpoint = sp.TAddress)
 
@@ -127,10 +123,6 @@ class LUWRepository(sp.Contract):
     def change_luw_state(self, luw_id, state_id):
         sp.set_type(luw_id, sp.TNat)
         sp.set_type(state_id, sp.TNat)
-
-        # Verifying whether the calling contract address is the logic contract
-        sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender,
-                  message="Incorrect caller")
 
         sp.verify(self.data.states.contains(state_id), message = "Incorrect state ID")
 
@@ -160,10 +152,6 @@ class LUWRepository(sp.Contract):
     def add_repository(self, luw_id, repository_id):
         sp.set_type(luw_id, sp.TNat)
         sp.set_type(repository_id, sp.TString)
-
-        # Verifying whether the calling contract address is the logic contract
-        sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender,
-                  message="Incorrect caller")
 
         owner_address = self.get_luw_owner_address(luw_id)
         sp.verify(self.verify_owner_source_address(
@@ -200,10 +188,6 @@ class LUWRepository(sp.Contract):
         sp.set_type(luw_id, sp.TNat)
         sp.set_type(repository_id, sp.TString)
         sp.set_type(state_id, sp.TNat)
-
-        # Verifying whether the calling contract address is the logic contract
-        sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender,
-                  message="Incorrect caller")
 
         owner_address = self.get_luw_owner_address(luw_id)
         sp.verify(self.verify_owner_source_address(

--- a/LUWRepository.py
+++ b/LUWRepository.py
@@ -3,10 +3,11 @@
 import smartpy as sp
 
 class LUWRepository(sp.Contract):
-    def __init__(self, luw_contract):
+    def __init__(self, luw_contract, certifier):
         self.init_type(
             sp.TRecord(
                 luw_contract = sp.TAddress,
+                certifier = sp.TAddress,
                 states = sp.TBigMap(
                     sp.TNat,
                     sp.TString
@@ -19,6 +20,7 @@ class LUWRepository(sp.Contract):
         )
         self.init(
             luw_contract = luw_contract,
+            certifier = certifier,
             states = sp.big_map({
                 1: "active",
                 2: "prepare_to_commit",
@@ -216,6 +218,26 @@ class LUWRepository(sp.Contract):
         # Calling the Storage contract with the parameters we defined
         sp.transfer(params, sp.mutez(0), luw_contract)
 
+    @sp.entry_point
+    def update_storage_contract_with_address(self):
+        # Update is allowed only from certifier
+        with sp.if_(self.data.certifier != sp.source):
+            sp.failwith("Incorrect certifier")
+
+        # Defining the data expected by the Storage contract
+        contract_data = sp.TAddress
+
+        # Defining the Storage contract itself and its entry point for the call
+        storage_contract = sp.contract(contract_data, self.data.luw_contract, "change_logic_contract_address").open_some()
+
+        # The contract's own address will be passed as a parameter
+        logic_contract_adrress = sp.self_address
+
+        # Calling the Storage contract with the parameters we defined
+        sp.transfer(logic_contract_adrress, sp.mutez(0), storage_contract)
+
+
+
     @sp.onchain_view()
     def fetch_luw(self, luw_id):
         # Defining the parameters' types
@@ -297,5 +319,5 @@ class LUWRepository(sp.Contract):
 @sp.add_test(name = "LUWRepository")
 def test():
     sp.add_compilation_target("luwRepository",
-        LUWRepository(sp.address("KT1_contract_address"))
+        LUWRepository(sp.address("KT1_contract_address"),sp.address('tz1_certifier_address'))
     )

--- a/assetProvider.py
+++ b/assetProvider.py
@@ -27,14 +27,14 @@ class AssetProvider(sp.Contract):
 
     @sp.entry_point
     def create_asset_provider(self, parameters):
-        # Verifying whether the caller address is the logic contract
+        # Verifying whether the calling contract address is the logic contract
         sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender, message="Incorrect caller")
 
         self.data.asset_providers[parameters.provider_id] = parameters
 
     @sp.entry_point
     def change_status(self, parameters):
-        # Verifying whether the caller address is the logic contract
+        # Verifying whether the calling contract address is the logic contract
         sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender, message="Incorrect caller")
 
         # Defining the parameters' types
@@ -50,14 +50,14 @@ class AssetProvider(sp.Contract):
 
     @sp.entry_point
     def change_data(self, parameters):
-        # Verifying whether the caller address is the logic contract
+        # Verifying whether the calling contract address is the logic contract
         sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender, message="Incorrect caller")
 
         # Defining the parameters' types
         sp.set_type(parameters.provider_id, sp.TString)
         sp.set_type(parameters.provider_data, sp.TString)
 
-        # Verifying whether the caller address is the logic contract
+        # Verifying whether the calling contract address is the logic contract
         # sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender, message = "Incorrect caller")
 
         provider_data = self.data.asset_providers[parameters.provider_id]
@@ -69,14 +69,14 @@ class AssetProvider(sp.Contract):
 
     @sp.entry_point
     def change_owner(self, parameters):
-        # Verifying whether the caller address is the logic contract
+        # Verifying whether the calling contract address is the logic contract
         sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender, message="Incorrect caller")
 
         # Defining the parameters' types
         sp.set_type(parameters.provider_id, sp.TString)
         sp.set_type(parameters.new_owner_address, sp.TAddress)
 
-        # Verifying whether the caller address is the logic contract
+        # Verifying whether the calling contract address is the logic contract
         # sp.verify(self.data.logic_contract_address.open_some(message="Empty logic_contract_address") == sp.sender, message = "Incorrect caller")
 
         provider_data = self.data.asset_providers[parameters.provider_id]

--- a/registry.py
+++ b/registry.py
@@ -216,6 +216,24 @@ class Registry(sp.Contract):
         # Calling the Logic contract with the parameters we defined
         sp.transfer(params, sp.mutez(0), logic_contract)
 
+    @sp.entry_point
+    def change_at_calling_contract(self):
+        # Only call from certifier is allowed
+        with sp.if_(self.data.certifier != sp.source):
+            sp.failwith("Incorrect certifier")
+
+        # Changes the calling contract address in the asset twin contract
+        contract_data=sp.TAddress
+
+        # Defining the Logic contract itself and its entry point for the call
+        logic_contract = sp.contract(contract_data, self.data.contracts.asset_twin_contract, "change_calling_contract_address").open_some(message="Erron in loading option contract")
+
+        # Defining the parameters that will be passed to the Storage contract
+        params = sp.self_address
+        # Calling the Storage contract with the parameters we defined
+        sp.transfer(params, sp.mutez(0), logic_contract)
+
+
     @sp.onchain_view()
     def fetch_asset_twin(self, parameters):
         # Defining the parameters' types
@@ -379,6 +397,7 @@ class Registry(sp.Contract):
         ).open_some("Invalid view");
 
         sp.result(repository_state)
+
 
 @sp.add_test(name = "Registry")
 def test():

--- a/testScenarios.py
+++ b/testScenarios.py
@@ -34,7 +34,7 @@ def test():
 
     scenario.h3("Asset Provider")
 
-    asset_provider = ASSET_PROVIDER.AssetProvider()
+    asset_provider = ASSET_PROVIDER.AssetProvider(certifier_address)
 
     scenario += asset_provider
 
@@ -43,26 +43,31 @@ def test():
     scenario.h3("Asset Provider Repository")
 
     asset_provider_repo = ASSET_PROVIDER_REPOSITORY.AssetProviderRepository(
-        asset_provider.address
+        asset_provider.address, certifier_address
     )
 
     scenario += asset_provider_repo
+
+    # Update logic contract address of the storage contract
+    scenario.h2("Updating storage contract with logic contract address for Asset Provider Repository")
+    asset_provider_repo.update_storage_contract_with_address().run(valid = True, sender = certifier_address)
 
     # Asset Twin  Contract Instantiation
 
     scenario.h3("Asset Twin Tracing")
 
     asset_twin_tracing = ASSET_TWIN_TRACING.AssetTwinTracing(
-        asset_provider.address
+        certifier_address
     )
 
     scenario += asset_twin_tracing
+
 
     # LUW Contract Instantiation
 
     scenario.h3("LUW")
 
-    luw_contract = LUW.LUW()
+    luw_contract = LUW.LUW(certifier_address)
 
     scenario += luw_contract
 
@@ -71,10 +76,14 @@ def test():
     scenario.h3("LUW Repository")
 
     luw_repo_contract = LUW_REPOSITORY.LUWRepository(
-        luw_contract.address
+        luw_contract.address, certifier_address
     )
 
     scenario += luw_repo_contract
+
+    # Update logic contract address of the storage contract
+    scenario.h2("Updating storage contract with logic contract address for LUW Repository")
+    luw_repo_contract.update_storage_contract_with_address().run(valid=True, sender=certifier_address)
 
     # Lambda Contract Instantiation
 
@@ -90,6 +99,11 @@ def test():
     )
 
     scenario += lambda_contract
+
+    # Update calling contract address of the asset twin contract to allow calls from the lambda contract
+
+    scenario.h2("Updating asset twin contract with calling contract address")
+    lambda_contract.change_at_calling_contract().run(valid=True, sender=certifier_address)
 
     # Testing 
 


### PR DESCRIPTION
These are the changes for checking the calling contract in:
- assetProvider.py (can only be called by assetProviderRepository.py)
- LUW.py (can only be called by LUWRepository.py)
- assetTwinTracint.py (can only be called by registry.py)

The corresponding calls to set the calling contracts address were implemented, as well as verifications that make sure only the certifier can call these updates.